### PR TITLE
Add favorites trigger and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# MapMarket Firebase
+
+This repository contains a minimalist demo of a map based marketplace powered entirely by Firebase.
+
+## Deployment
+
+1. Create a Firebase project and configure `.firebaserc` with your project id.
+2. Install the Firebase CLI then run the following commands:
+
+```bash
+firebase use <your-project-id>
+firebase deploy
+```
+
+## Firestore Indexes
+
+Indexes used by the application are defined in `firestore.indexes.json`. Run `firebase deploy --only firestore:indexes` to deploy them.
+
+## Environment variables
+
+Cloud Functions expect a file named `env.local` at the project root to define environment configuration such as Algolia credentials. Copy `env.local.example` and adjust the values:
+
+```bash
+cp env.local.example env.local
+```
+
+## Tests
+
+Unit tests (if any) can be executed with `npm test` inside the `functions` directory.

--- a/env.local.example
+++ b/env.local.example
@@ -1,0 +1,3 @@
+ALGOLIA_APP_ID=your-app-id
+ALGOLIA_API_KEY=your-api-key
+ALGOLIA_INDEX_NAME=ads

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,8 +15,8 @@ import { onUserCreate } from "./auth";
 export { onUserCreate };
 
 // Fonctions déclenchées par Firestore (annonces, messages, avis)
-import { onAdWrite, onMessageCreate, onReviewCreate } from "./firestoreTriggers";
-export { onAdWrite, onMessageCreate, onReviewCreate };
+import { onAdWrite, onMessageCreate, onReviewCreate, onFavoriteWrite } from "./firestoreTriggers";
+export { onAdWrite, onMessageCreate, onReviewCreate, onFavoriteWrite };
 
 // Fonctions planifiées (cron jobs)
 import { cleanupInactiveUsers } from "./scheduled";


### PR DESCRIPTION
## Summary
- document deployment and env setup in README
- provide example env file for Cloud Functions
- notify sellers when an ad is favorited
- track favorites count via Firestore trigger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842cd326b54832eb7d1a5af744d443f