### PR TITLE
Implement simple ad detail modal

### DIFF
--- a/public/js/ad-detail.js
+++ b/public/js/ad-detail.js
@@ -1,0 +1,56 @@
+export function initAdDetail() {
+    document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('[data-action="open-ad-detail"]');
+        if (btn) {
+            e.preventDefault();
+            const adId = btn.dataset.id;
+            if (adId) {
+                await showAdDetail(adId);
+            }
+        }
+    });
+}
+
+import { openModal, closeModal } from './ui.js';
+import { fetchAdById } from './services.js';
+import { showToast } from './utils.js';
+
+async function showAdDetail(adId) {
+    const modal = document.getElementById('ad-detail-modal');
+    const loader = document.getElementById('ad-detail-loader');
+    const content = document.getElementById('ad-detail-content');
+    openModal('ad-detail-modal');
+    modal.dataset.adId = adId;
+    loader.classList.remove('hidden');
+    content.classList.add('hidden');
+    try {
+        const ad = await fetchAdById(adId);
+        if (!ad) throw new Error('Annonce introuvable');
+        document.getElementById('ad-detail-item-title').textContent = ad.title;
+        document.getElementById('ad-detail-price').textContent = `${ad.price} €`;
+        document.getElementById('ad-detail-description-text').textContent = ad.description || '';
+        document.getElementById('ad-detail-category').innerHTML = `<i class="fa-solid fa-tag"></i> ${ad.categoryId}`;
+        document.getElementById('ad-detail-location').innerHTML = `<i class="fa-solid fa-map-marker-alt"></i> ${ad.location?.address || ''}`;
+        if (ad.createdAt?.seconds) {
+            const d = new Date(ad.createdAt.seconds * 1000);
+            document.getElementById('ad-detail-date').innerHTML = `<i class="fa-solid fa-calendar-days"></i> ${d.toLocaleDateString()}`;
+        }
+        const track = document.getElementById('ad-detail-carousel-track');
+        track.innerHTML = '';
+        if (Array.isArray(ad.images)) {
+            ad.images.forEach(url => {
+                const img = document.createElement('img');
+                img.src = url;
+                img.alt = ad.title;
+                img.loading = 'lazy';
+                track.appendChild(img);
+            });
+        }
+        loader.classList.add('hidden');
+        content.classList.remove('hidden');
+    } catch (err) {
+        console.error(err);
+        loader.querySelector('p').textContent = "Erreur lors du chargement";
+        showToast("Impossible d'afficher l'annonce", "error");
+    }
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -8,6 +8,7 @@ import { setupAuthListeners } from './auth.js';
 import { initUIManager } from './ui.js';
 import { initializeMap } from './map.js';
 import { initAdManager } from './ad-manager.js';
+import { initAdDetail } from './ad-detail.js';
 import { initChat } from './chat.js';
 import { showToast, showGlobalLoader, hideGlobalLoader } from './utils.js';
 import { fetchCategories } from './services.js';
@@ -50,6 +51,7 @@ async function main() {
         
         // 5. Initialise les modules de fonctionnalités.
         initAdManager();
+        initAdDetail();
         initChat();
 
         console.log("MapMarket initialisé avec succès.");

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -9,6 +9,7 @@ const ASSETS = [
   '/js/firebase.js',
   '/js/auth.js',
   '/js/ad-manager.js',
+  '/js/ad-detail.js',
   '/js/chat.js',
   '/js/map.js',
   '/js/services.js',


### PR DESCRIPTION
## Summary
- add ad-detail module to fetch and display ad info
- init ad detail module from main entry
- cache new module in service worker

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6842f4340bdc832e94e6dd370ddc718e